### PR TITLE
fix nob.c for windows

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -1,5 +1,10 @@
+#ifdef __WIN32
+#include <windows.h>
+#endif
+
 #define NOB_IMPLEMENTATION
 #include "nob.h"
+
 
 void append_warnings(Nob_Cmd *cmd) {
 	nob_cmd_append(cmd, "-Wall", "-Wextra", "-Werror");
@@ -37,7 +42,11 @@ void include_common(Nob_Cmd *cmd) { nob_cmd_append(cmd, "-I./include"); }
 void link_math(Nob_Cmd *cmd) { nob_cmd_append(cmd, "-lm"); }
 
 bool for_windows(char *CC) {
+	#ifdef __WIN32
+	return 1;
+	#else
 	return (CC != NULL && strcmp(CC, "x86_64-w64-mingw32-gcc") == 0);
+	#endif
 }
 
 int build_client(void) {


### PR DESCRIPTION
- the windows check only seems to work if you're cross compiling on linux, this returns 1 if you're compiling on windows

- compiling on windows has some errors because of missing windows defines, this includes `windows.h`, thus adding the missing defines

Support for compiling on macOS can be done in a similar manner.  