### PR TITLE
fix compiling on macOS

### DIFF
--- a/include/mesh.h
+++ b/include/mesh.h
@@ -7,15 +7,8 @@
 
 #include <stdbool.h>
 
-#ifdef __APPLE__
-#include <OpenGL/gl.h>
-#else
-#include <GL/gl.h>
-#endif
-
 typedef struct {
-	GLfloat position[3];  // 12 bytes
-	// GLfloat color[3];     // 12 bytes
+	float position[3];  // 12 bytes
 	uint32_t type;        // 4 bytes
 	uint32_t normal;      // 4 bytes
 } Vertex;  // 36 bytes

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -6,7 +6,12 @@
 #include "world.h"
 
 #include <stdbool.h>
+
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 
 typedef struct {
 	GLfloat position[3];  // 12 bytes

--- a/src/client/camera.c
+++ b/src/client/camera.c
@@ -4,10 +4,6 @@
 #include "camera.h"
 #include <math.h>
 
-#ifndef M_PI_2
-#define M_PI_2 1.57079632679489661923 /* pi/2 */
-#endif
-
 void camera_update(Camera *camera, bool keys[1024], float dx, float dy,
 				   float dt) {
 	// Update camera rotation

--- a/src/client/camera.c
+++ b/src/client/camera.c
@@ -4,7 +4,9 @@
 #include "camera.h"
 #include <math.h>
 
+#ifndef M_PI_2
 #define M_PI_2 1.57079632679489661923 /* pi/2 */
+#endif
 
 void camera_update(Camera *camera, bool keys[1024], float dx, float dy,
 				   float dt) {

--- a/src/client/window.c
+++ b/src/client/window.c
@@ -64,6 +64,7 @@ MyWindow createWindow(int width, int height) {
 }
 
 int initWindow(MyWindow* window) {
+	RGFW_setGLVersion(RGFW_GL_CORE, 3, 3);
 	window->window = RGFW_createWindow("Voxels", (RGFW_rect) {0, 0, 800, 600}, RGFW_CENTER | RGFW_HIDE_MOUSE);
 	info("The window has been initialized.");
 


### PR DESCRIPTION
Compiling on MacOS with nob works fine except for some errors created by voxels

1) MacOS uses `OpenGL/gl.h` rather than `GL/gl.h` 

2) There was a redefine error for `M_PI_2` 

Although this PR fixes those compile-time errors, there is also a runtime error/crash related to rendering when I run `./build/client` 

The error log for the GLSL compilation says 
> Version '330' is not supported. 

This could be a problem with the macOS machine I'm using or with macOS itself. Testing on a different Mac computer would be able to diagnose this issue. 

However, this confuses me because, for the gl33 example, I believe I also used `version 330 core`.